### PR TITLE
Fix Project Page Subheading Display Bug

### DIFF
--- a/components/gradientBanner.jsx
+++ b/components/gradientBanner.jsx
@@ -30,7 +30,7 @@ const GradientBanner = ({ title, subHeadline, style, arrow, children }) => (
                   <div style={props} className="text-center sub-headline">
                     {/* if it has a json key, we'll assume it's Rich Text from Contentful */}
                     {subHeadline.json ? (
-                      <ContentBlock content={subHeadline} />
+                      <ContentBlock content={subHeadline.json} />
                     ) : (
                       <p>{subHeadline}</p>
                     )}


### PR DESCRIPTION
Added a .json that was missing to display project descriptions on projectslug page. Issue was passing the entire rich text object to Contentblock, not just the json object. 

Before:
![before](https://user-images.githubusercontent.com/26028530/111076540-0efec980-84c3-11eb-8750-046f215d3b77.jpg)
After:
![after](https://user-images.githubusercontent.com/26028530/111076541-11612380-84c3-11eb-8aa6-b9cd565f09b8.jpg)
